### PR TITLE
dialoge in unit tests vermeiden

### DIFF
--- a/SS23-SWEN2-TourPlanner-WPF.BL/FileDialogService.cs
+++ b/SS23-SWEN2-TourPlanner-WPF.BL/FileDialogService.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SS23_SWEN2_TourPlanner_WPF.BL
+{
+    public class FileDialogService : IFileDialogService
+    {
+        OpenFileDialog IFileDialogService.OpenFileDialog()
+        {
+            return new OpenFileDialog();
+        }
+
+        SaveFileDialog IFileDialogService.SaveFileDialog()
+        {
+            return new SaveFileDialog();
+        }
+    }
+}

--- a/SS23-SWEN2-TourPlanner-WPF.BL/IFileDialogService.cs
+++ b/SS23-SWEN2-TourPlanner-WPF.BL/IFileDialogService.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SS23_SWEN2_TourPlanner_WPF.BL
+{
+    public interface IFileDialogService
+    {
+        public SaveFileDialog SaveFileDialog();
+        public OpenFileDialog OpenFileDialog();
+    }
+}

--- a/SS23-SWEN2-TourPlanner-WPF.BL/IMessageBoxService.cs
+++ b/SS23-SWEN2-TourPlanner-WPF.BL/IMessageBoxService.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace SS23_SWEN2_TourPlanner_WPF.BL
+{
+    public interface IMessageBoxService
+    {
+        MessageBoxResult Show(string text, string caption = "", MessageBoxButton button = MessageBoxButton.OK, MessageBoxImage icon = MessageBoxImage.Information, MessageBoxResult defaultResult = MessageBoxResult.None, MessageBoxOptions options = MessageBoxOptions.None);
+    }
+}

--- a/SS23-SWEN2-TourPlanner-WPF.BL/MessageBoxService.cs
+++ b/SS23-SWEN2-TourPlanner-WPF.BL/MessageBoxService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace SS23_SWEN2_TourPlanner_WPF.BL
+{
+    public class MessageBoxService : IMessageBoxService
+    {
+        public MessageBoxResult Show(string text, string caption = "", MessageBoxButton button = MessageBoxButton.OK, MessageBoxImage icon = MessageBoxImage.Asterisk, MessageBoxResult defaultResult = MessageBoxResult.None, MessageBoxOptions options = MessageBoxOptions.None)
+        {
+            return MessageBox.Show(text, caption, button, icon, defaultResult, options);
+        }
+    }
+}

--- a/SS23-SWEN2-TourPlanner-WPF.BL/Report.cs
+++ b/SS23-SWEN2-TourPlanner-WPF.BL/Report.cs
@@ -15,13 +15,6 @@ namespace SS23_SWEN2_TourPlanner_WPF.BL
 {
     public class Report
     {
-        private SaveFileDialog CreateSaveFileDialog()
-        {
-            SaveFileDialog saveFileDialog = new SaveFileDialog();
-            saveFileDialog.Filter = "PDF Files (*.pdf)|*.pdf";
-            return saveFileDialog;
-        }
-
         private void AddHeader(Document document, string headerText, int fontSize = 32, bool isBold = true, iText.Kernel.Colors.Color fontColor = null)
         {
             var header = new Paragraph(headerText);
@@ -102,62 +95,36 @@ namespace SS23_SWEN2_TourPlanner_WPF.BL
             AddImage(document, tour.Image);
         }
 
-        public void CreateReport(ObservableCollection<Tour> tours, string? filepath = null)
+        public void CreateReport(ObservableCollection<Tour> tours, string filepath)
         {
-            // Show save file dialog if no filepath was provided
-            if (string.IsNullOrEmpty(filepath))
+            // Create the PDF report
+            PdfWriter writer = new PdfWriter(filepath);
+            var pdf = new PdfDocument(writer);
+            var document = new Document(pdf);
+
+            foreach (Tour tour in tours)
             {
-                SaveFileDialog saveFileDialog = CreateSaveFileDialog();
-                if (saveFileDialog.ShowDialog() == true)
-                {
-                    filepath = saveFileDialog.FileName;
-                }
+                document.Add(new AreaBreak(AreaBreakType.NEXT_PAGE));
+                CreateTourReport(document, tour);
             }
 
-            if (!string.IsNullOrEmpty(filepath))
-            {
-                // Create the PDF report
-                PdfWriter writer = new PdfWriter(filepath);
-                var pdf = new PdfDocument(writer);
-                var document = new Document(pdf);
-
-                foreach (Tour tour in tours)
-                {
-                    document.Add(new AreaBreak(AreaBreakType.NEXT_PAGE));
-                    CreateTourReport(document, tour);
-                }
-
-                document.Close();
-            }
+            document.Close();
         }
 
-        public void CreateReport(Tour tour, string? filepath = null)
+        public void CreateReport(Tour tour, string filepath)
         {
-            // Show save file dialog if no filepath was provided
-            if (string.IsNullOrEmpty(filepath))
-            {
-                SaveFileDialog saveFileDialog = CreateSaveFileDialog();
-                if (saveFileDialog.ShowDialog() == true)
-                {
-                    filepath = saveFileDialog.FileName;
-                }
-            }
+            // Create the PDF report
+            var writer = new PdfWriter(filepath);
+            var pdf = new PdfDocument(writer);
+            var document = new Document(pdf);
 
-            if (!string.IsNullOrEmpty(filepath))
-            {
-                // Create the PDF report
-                var writer = new PdfWriter(filepath);
-                var pdf = new PdfDocument(writer);
-                var document = new Document(pdf);
+            AddHeader(document, tour.Name);
+            AddHeader(document, "Tour Report");
+            AddHeader(document, DateTime.Now.ToString("dd.MMM yyyy"), fontColor: iText.Kernel.Colors.ColorConstants.LIGHT_GRAY);
 
-                AddHeader(document, tour.Name);
-                AddHeader(document, "Tour Report");
-                AddHeader(document, DateTime.Now.ToString("dd.MMM yyyy"), fontColor: iText.Kernel.Colors.ColorConstants.LIGHT_GRAY);
+            CreateTourReport(document, tour);
 
-                CreateTourReport(document, tour);
-
-                document.Close();
-            }
+            document.Close();
         }
     }
 }

--- a/SS23-SWEN2-TourPlanner-WPF.Tests/SS23-SWEN2-TourPlanner-WPF.Tests.csproj
+++ b/SS23-SWEN2-TourPlanner-WPF.Tests/SS23-SWEN2-TourPlanner-WPF.Tests.csproj
@@ -20,10 +20,18 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\SS23-SWEN2-TourPlanner-WPF.BL\SS23-SWEN2-TourPlanner-WPF.BL.csproj" />
+    <ProjectReference Include="..\SS23-SWEN2-TourPlanner-WPF.DAL\SS23-SWEN2-TourPlanner-WPF.DAL.csproj" />
+    <ProjectReference Include="..\SS23-SWEN2-TourPlanner-WPF.Models\SS23-SWEN2-TourPlanner-WPF.Models.csproj" />
     <ProjectReference Include="..\SS23-SWEN2-TourPlanner-WPF\SS23-SWEN2-TourPlanner-WPF.csproj" />
   </ItemGroup>
 
+	<Target Name="CopyConfig" AfterTargets="Build">
+		<Copy SourceFiles="..\SS23-SWEN2-TourPlanner-WPF\App.config"     
+			  DestinationFiles="$(TargetDir)testhost.dll.config"/>
+	</Target>
 </Project>

--- a/SS23-SWEN2-TourPlanner-WPF.Tests/ViewModels/TourLogsViewModelTest.cs
+++ b/SS23-SWEN2-TourPlanner-WPF.Tests/ViewModels/TourLogsViewModelTest.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Security.RightsManagement;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace SS23_SWEN2_TourPlanner_WPF.Tests.ViewModels
 {
@@ -15,6 +16,7 @@ namespace SS23_SWEN2_TourPlanner_WPF.Tests.ViewModels
     public class TourLogsViewModelTest
     {
         private Mock<IToursManager> _toursManagerMock;
+        private Mock<IMessageBoxService> _messageBoxServiceMock;
         private TourLogsViewModel _viewModel;
         private Tour _tour;
 
@@ -22,6 +24,8 @@ namespace SS23_SWEN2_TourPlanner_WPF.Tests.ViewModels
         public void Setup()
         {
             _toursManagerMock = new Mock<IToursManager>();
+            _messageBoxServiceMock = new Mock<IMessageBoxService>();
+            _messageBoxServiceMock.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButton>(), It.IsAny<MessageBoxImage>(), It.IsAny<MessageBoxResult>(), It.IsAny<MessageBoxOptions>())).Returns(MessageBoxResult.Yes);
             _tour = new Tour("Test-Tour")
             {
                 Id = 1,
@@ -30,7 +34,7 @@ namespace SS23_SWEN2_TourPlanner_WPF.Tests.ViewModels
             _tour.TourLogs.Add(new TourLog() { Id = 1 });
             _tour.TourLogs.Add(new TourLog() { Id = 2 });
 
-            _viewModel = new TourLogsViewModel(_toursManagerMock.Object, _tour);
+            _viewModel = new TourLogsViewModel(_toursManagerMock.Object, _messageBoxServiceMock.Object, _tour);
         }
 
         [Test]

--- a/SS23-SWEN2-TourPlanner-WPF.Tests/ViewModels/ToursViewModelTest.cs
+++ b/SS23-SWEN2-TourPlanner-WPF.Tests/ViewModels/ToursViewModelTest.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Moq;
+using System.Windows;
 
 namespace SS23_SWEN2_TourPlanner_WPF.Tests.ViewModels
 {
@@ -16,12 +17,15 @@ namespace SS23_SWEN2_TourPlanner_WPF.Tests.ViewModels
     {
         private ToursViewModel _viewModel;
         private Mock<IToursManager> _toursManagerMock;
+        private Mock<IMessageBoxService> _messageBoxServiceMock;
 
         [SetUp]
         public void Setup()
         {
             _toursManagerMock = new Mock<IToursManager>();
-            _viewModel = new ToursViewModel(_toursManagerMock.Object);
+            _messageBoxServiceMock = new Mock<IMessageBoxService>();
+            _messageBoxServiceMock.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButton>(), It.IsAny<MessageBoxImage>(), It.IsAny<MessageBoxResult>(), It.IsAny<MessageBoxOptions>())).Returns(MessageBoxResult.Yes);
+            _viewModel = new ToursViewModel(_toursManagerMock.Object, _messageBoxServiceMock.Object);
         }
 
         [Test]
@@ -36,7 +40,7 @@ namespace SS23_SWEN2_TourPlanner_WPF.Tests.ViewModels
             _toursManagerMock.Setup(tm => tm.GetTours()).Returns(expectedTours);
 
             // Act
-            _viewModel = new ToursViewModel(_toursManagerMock.Object);
+            _viewModel = new ToursViewModel(_toursManagerMock.Object, _messageBoxServiceMock.Object);
 
             // Assert
             Assert.That(expectedTours, Has.Count.EqualTo(2));
@@ -48,7 +52,7 @@ namespace SS23_SWEN2_TourPlanner_WPF.Tests.ViewModels
         }
 
         [Test]
-        public void DeleteTourCommand_ShouldRemoveTourFromManagerAndList()
+        public void DeleteTourCommand_ShouldRemoveTourFromManager()
         {
             // Arrange
             var tourToDelete = new Tour("Tour 1") { Id = 1 };
@@ -62,7 +66,6 @@ namespace SS23_SWEN2_TourPlanner_WPF.Tests.ViewModels
 
             // Assert
             _toursManagerMock.Verify(tm => tm.DeleteTour(tourToDelete), Times.Once);
-            Assert.That(_viewModel.Tours, Does.Not.Contain(tourToDelete));
         }
     }
 }

--- a/SS23-SWEN2-TourPlanner-WPF.Tests/ViewModels/ToursViewModelTest.cs
+++ b/SS23-SWEN2-TourPlanner-WPF.Tests/ViewModels/ToursViewModelTest.cs
@@ -18,14 +18,16 @@ namespace SS23_SWEN2_TourPlanner_WPF.Tests.ViewModels
         private ToursViewModel _viewModel;
         private Mock<IToursManager> _toursManagerMock;
         private Mock<IMessageBoxService> _messageBoxServiceMock;
+        private Mock<IFileDialogService> _fileDialogServiceMock;
 
         [SetUp]
         public void Setup()
         {
             _toursManagerMock = new Mock<IToursManager>();
             _messageBoxServiceMock = new Mock<IMessageBoxService>();
+            _fileDialogServiceMock = new Mock<IFileDialogService>();
             _messageBoxServiceMock.Setup(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButton>(), It.IsAny<MessageBoxImage>(), It.IsAny<MessageBoxResult>(), It.IsAny<MessageBoxOptions>())).Returns(MessageBoxResult.Yes);
-            _viewModel = new ToursViewModel(_toursManagerMock.Object, _messageBoxServiceMock.Object);
+            _viewModel = new ToursViewModel(_toursManagerMock.Object, _messageBoxServiceMock.Object, _fileDialogServiceMock.Object);
         }
 
         [Test]
@@ -40,7 +42,7 @@ namespace SS23_SWEN2_TourPlanner_WPF.Tests.ViewModels
             _toursManagerMock.Setup(tm => tm.GetTours()).Returns(expectedTours);
 
             // Act
-            _viewModel = new ToursViewModel(_toursManagerMock.Object, _messageBoxServiceMock.Object);
+            _viewModel = new ToursViewModel(_toursManagerMock.Object, _messageBoxServiceMock.Object, _fileDialogServiceMock.Object);
 
             // Assert
             Assert.That(expectedTours, Has.Count.EqualTo(2));

--- a/SS23-SWEN2-TourPlanner-WPF/App.xaml.cs
+++ b/SS23-SWEN2-TourPlanner-WPF/App.xaml.cs
@@ -42,6 +42,7 @@ namespace SS23_SWEN2_TourPlanner_WPF
             // create all layers
             services.AddSingleton<IDataManager, DataManagerEFImpl>();
             services.AddSingleton<IToursManager, ToursManagerImpl>();
+            services.AddSingleton<IMessageBoxService, MessageBoxService>();
 
             // create viewmodels
             services.AddSingleton<ToursViewModel>();

--- a/SS23-SWEN2-TourPlanner-WPF/App.xaml.cs
+++ b/SS23-SWEN2-TourPlanner-WPF/App.xaml.cs
@@ -43,6 +43,7 @@ namespace SS23_SWEN2_TourPlanner_WPF
             services.AddSingleton<IDataManager, DataManagerEFImpl>();
             services.AddSingleton<IToursManager, ToursManagerImpl>();
             services.AddSingleton<IMessageBoxService, MessageBoxService>();
+            services.AddSingleton<IFileDialogService, FileDialogService>();
 
             // create viewmodels
             services.AddSingleton<ToursViewModel>();

--- a/SS23-SWEN2-TourPlanner-WPF/ViewModels/TourLogsViewModel.cs
+++ b/SS23-SWEN2-TourPlanner-WPF/ViewModels/TourLogsViewModel.cs
@@ -16,6 +16,7 @@ namespace SS23_SWEN2_TourPlanner_WPF.ViewModels
     public class TourLogsViewModel : BaseViewModel
     {
         private IToursManager _toursManager;
+        private readonly IMessageBoxService messageBoxService;
         public ObservableCollection<TourLog> TourLogs { get; set; } = new ObservableCollection<TourLog>();
 
         public RelayCommand AddTourLogCommand { get; set; }
@@ -39,9 +40,10 @@ namespace SS23_SWEN2_TourPlanner_WPF.ViewModels
 
         private TourLog? _currentTourLog;
 
-        public TourLogsViewModel(IToursManager toursManager, Tour tour)
+        public TourLogsViewModel(IToursManager toursManager, IMessageBoxService messageBoxService, Tour tour)
         {
             _toursManager = toursManager;
+            this.messageBoxService = messageBoxService;
             tour.TourLogs.ForEach(tourLog =>
             {
                 TourLogs.Add(tourLog);
@@ -66,7 +68,7 @@ namespace SS23_SWEN2_TourPlanner_WPF.ViewModels
             DeleteTourLogCommand = new RelayCommand(_ => {
                 if (CurrentTourLog != null)
                 {
-                    if (MessageBox.Show("Do you really want to delete this Tourlog?",
+                    if (messageBoxService.Show("Do you really want to delete this Tourlog?",
                     "Delete Tourlog",
                     MessageBoxButton.YesNo,
                     MessageBoxImage.Question) == MessageBoxResult.Yes)

--- a/SS23-SWEN2-TourPlanner-WPF/ViewModels/ToursViewModel.cs
+++ b/SS23-SWEN2-TourPlanner-WPF/ViewModels/ToursViewModel.cs
@@ -17,6 +17,7 @@ namespace SS23_SWEN2_TourPlanner_WPF.ViewModels
     {
         private readonly IToursManager toursmanager;
         private readonly IMessageBoxService messageBoxService;
+        private readonly IFileDialogService fileDialogService;
         public TourLogsViewModel? TourLogsVM { get; set; }
 
         public ObservableCollection<Tour> Tours { get; } = new();
@@ -63,10 +64,11 @@ namespace SS23_SWEN2_TourPlanner_WPF.ViewModels
             get { return CurrentTour != null; }
         }
 
-        public ToursViewModel(IToursManager toursManager, IMessageBoxService messageBoxService)
+        public ToursViewModel(IToursManager toursManager, IMessageBoxService messageBoxService, IFileDialogService fileDialogService)
         {
             this.toursmanager = toursManager;
             this.messageBoxService = messageBoxService;
+            this.fileDialogService = fileDialogService;
             toursManager.GetTours().ToList().ForEach(t => Tours.Add(t));
             toursManager.GetTourLogs();
             this.CreateTourCommand = new RelayCommand(param =>
@@ -122,16 +124,32 @@ namespace SS23_SWEN2_TourPlanner_WPF.ViewModels
             });
             this.ExportReportCommand = new RelayCommand(_ =>
             {
-                Report report = new Report();
-                report.CreateReport(Tours);
+                var saveFileDialog = fileDialogService.SaveFileDialog();
+                saveFileDialog.Filter = "PDF Files (*.pdf)|*.pdf";
+
+                saveFileDialog.ShowDialog();
+
+                if (!string.IsNullOrEmpty(saveFileDialog.FileName))
+                {
+                    Report report = new();
+                    report.CreateReport(Tours, saveFileDialog.FileName);
+                }
             });
             this.ExportSingleReportCommand = new RelayCommand(_ =>
             {
                 if (CurrentTour == null)
                     return;
 
-                Report report = new Report();
-                report.CreateReport(CurrentTour);
+                var saveFileDialog = fileDialogService.SaveFileDialog();
+                saveFileDialog.Filter = "PDF Files (*.pdf)|*.pdf";
+
+                saveFileDialog.ShowDialog();
+
+                if (!string.IsNullOrEmpty(saveFileDialog.FileName))
+                {
+                    Report report = new();
+                    report.CreateReport(CurrentTour, saveFileDialog.FileName);
+                }
             });
 
             // handle errors from tourmanager


### PR DESCRIPTION
Hab ich jetzt gelöst, indem ich einen MessageBoxService erstellt habe. Wenn man diesen Service verwendet, um Messageboxen zu erstellen, dann kann man in den UnitTests die entsprechenden Benutzereingaben Mocken :)

Achso ja und die App.config Datei kann jetzt auch von dem Test-Runner gelesen werden. 📚 👓 

closes #49
closes #61 